### PR TITLE
connection pooling settings added to mysql connector

### DIFF
--- a/configs/setup.go
+++ b/configs/setup.go
@@ -9,7 +9,7 @@ import (
 
 var confs Config
 
-func ConnectMySQL() (db *sql.DB) {
+func ConnectMySQL(setLimits bool) *sql.DB {
 	confs, _ = LoadConfig()
 
 	address := confs.MySql.Address
@@ -20,6 +20,7 @@ func ConnectMySQL() (db *sql.DB) {
 	port := confs.MySql.Port
 
 	connectionString := user + ":" + password + "@tcp(" + address + ":" + port + ")/" + schema
+
 	db, err := sql.Open(driver, connectionString)
 
 	if err != nil {
@@ -27,7 +28,10 @@ func ConnectMySQL() (db *sql.DB) {
 		log.Fatal("could not connect to mysql database. Error:", string(err.Error()))
 	}
 
-	log.Println("connected to mysql Database.")
+	if setLimits {
+		db.SetMaxOpenConns(10)
+		db.SetMaxIdleConns(10)
+	}
 
 	return db
 }

--- a/service/dbinit.go
+++ b/service/dbinit.go
@@ -6,4 +6,7 @@ import (
 	"github.com/mateenbagheri/mysmall-wallet/configs"
 )
 
-var Mysql *sql.DB = configs.ConnectMySQL()
+
+const setLimits bool = true
+
+var Mysql *sql.DB = configs.ConnectMySQL(setLimits)


### PR DESCRIPTION
if needed, one can always get back to default connection pooling settings with setting the setLimits in dbinit.go to false.